### PR TITLE
Updates sidebar styles to accomodate more scroll menu

### DIFF
--- a/themes/cupper/static/css/styles.css
+++ b/themes/cupper/static/css/styles.css
@@ -621,7 +621,7 @@ caption {
 }
 
 .intro-and-nav>div {
-    padding: 2.25rem;
+    padding: 1.5rem 1.25rem;
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -629,6 +629,7 @@ caption {
 
 .intro {
     flex: 0 0 auto;
+    line-height: 1.3;
 }
 
 .patterns {
@@ -640,6 +641,7 @@ caption {
     display: flex;
     column-gap: 24px;
     align-items: center;
+    justify-content: center;
 
     .logo-text {
         display: flex;
@@ -659,7 +661,7 @@ caption {
 
 .logo img {
     width: 100%;
-    /* max-width: 5rem; */
+    max-width: 250px;
 }
 
 .library-desc {
@@ -671,7 +673,7 @@ caption {
 }
 
 .main-and-footer {
-    margin-left: 15rem;
+    margin-left: 18rem;
 }
 
 .main-and-footer>div {
@@ -690,7 +692,7 @@ caption {
 
 .patterns {
     overflow: auto;
-    margin-top: 1.5rem;
+    margin-top: 1.125rem;
 }
 
 .patterns * {
@@ -698,7 +700,8 @@ caption {
 }
 
 .patterns h3 {
-    font-size: 1rem;
+    font-size: 0.9rem;
+    line-height: 1.4;
 }
 
 .patterns h3+ul {
@@ -711,11 +714,7 @@ caption {
 }
 
 .patterns li+li {
-    margin-top: 0.75rem;
-}
-
-.patterns ul ul {
-    margin-left: 0.75rem;
+    margin-top: 0.8rem;
 }
 
 .pattern a {
@@ -724,7 +723,7 @@ caption {
     flex-wrap: nowrap;
     align-items: center;
     font-weight: bold;
-    padding: 0 1rem;
+    padding: 0 0.625rem;
 }
 
 
@@ -1308,7 +1307,7 @@ h1 svg {
     }
 
     .intro-and-nav>div {
-        padding: 1.5rem;
+        padding: 1rem;
     }
 
     .main-and-footer {
@@ -1331,10 +1330,6 @@ h1 svg {
 
     .patterns li:not(.pattern) {
         margin-top: 0;
-    }
-
-    .patterns ul ul {
-        margin: 0;
     }
 
     .patterns li {
@@ -1477,7 +1472,7 @@ h1 svg {
 
 .pattern a span.text {
     font-family: JetBrains Mono, monospace;
-    line-height: 1.2rem;
+    line-height: 1.2;
 }
 
 .sidebar-headings {


### PR DESCRIPTION
I have made a bunch of changes kind of taking from the ideas that @Erioldoesdesign had implemented [here](https://github.com/simplysecure/user_project_website/issues/60#issuecomment-1612714716). I have tried to reduce the paddings and margins more than the font-size itself, since reducing fonts below 16px made them look really small I think.

This is the screenshot of current sidebar in a laptop screen:
![image](https://github.com/simplysecure/user_project_website/assets/9530293/000f5e93-f6b6-4391-a986-cb9fa675196c)


This is the screenshot after the changes in this PR:
![image](https://github.com/simplysecure/user_project_website/assets/9530293/b137dccd-3107-4015-8d56-aa90a9ae7676)


Mostly things I have done are:
- reduce left and right paddings in the entire sidebar to give more space for the text
- reduce size of image and centre aligned
- reduce line heights and font-sizes of the texts
- reduce margin slightly in-between the different items.

Let me know if this looks too crowded and you would prefer something else. cc @Erioldoesdesign @georgiamoon 

Resolves #60 