### PR TITLE
Updates findings to be process in admin config

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -35,9 +35,9 @@ collections:
       - { name: "tag", label: "Tag(s)", widget: "text", required: false  }
       - { name: "featuredImage", label: "Featured Image", widget: "image", required: false }
       - { name: "body", label: "Body", widget: "markdown" }
-  - name: "findings"
-    label: "Findings"
-    folder: "content/findings"
+  - name: "process"
+    label: "Process"
+    folder: "content/process"
     create: true
     slug: "{{slug}}"
     fields:


### PR DESCRIPTION
As reported by @Erioldoesdesign , I think the files in findings are not showing in admin, because the title and folder names were changed manually in the repo. I have updated the config file for admin in this PR. That should hopefully fix the issue.