### PR TITLE
Fixes list styling across the website

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -9,15 +9,10 @@ We investigated how norms in academic, science, and/or open source working envir
 # Our initial research goals
 
 - Do scientific open source projects think about their users?
-
 - When and how do scientific open source projects prioritize usability & design?
-
 - How do scientific open source software projects currently incorporate user-focused practices? What are the contributing factors that lead to successful adoption of these practices?
-
 - Is language for usability and design used consistently? What do contributors understand about the words “usability” and “design,” and what word choices do they make when describing challenges and opportunities focusing on end-user experience?
-
 - How do the resources, tools and infrastructure in use affect when a project team decides to prioritize usability, and when is that most successful?
-
 - How do creators of open source research software think and act in relation to the users of their software? What are the heuristics that drive the development of their software?
 
 # Explore the research findings

--- a/content/about/design-curriculum-for-science-research-oss.md
+++ b/content/about/design-curriculum-for-science-research-oss.md
@@ -11,12 +11,11 @@ This sample curriculum was developed by our USER researchers to address some of 
 **Understanding different contributors’ perspectives and intentions for tool use.**
 
 What gets built with whom is important. Sure, one can develop a "computation for X" and then try to make it usable. But is this mostly helpful for computational approaches to increase a SROSS project’s reach or helpful for addressing users’ current concerns. Understanding what a SROSS tool hopes to achieve for who early on will help with a design approach which is centered on a more broadly relevant spectrum of users.
-    
-- **Value propositions** help SROSS projects better identify the core values of the tool and who it serves. Doing many value propositions as a team helps to further narrow down the multiple purposes of an SROSS project from various user perspectives. This also uncovers the differing perspectives from team members, maintainers and community contributors on ‘who’ the SROSS serves and why and helps to communicate overall expectations and goals for the SROSS. It also helps uncover assumptions people working in the SROSS have about their users. We recommend doing this exercise whenever there is strategical shift in the project or user base.
-        - Time needed for exercise: 1-2 hours
-        - Recommended size of group: 1-8
-        - Template: [Value Proposition](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559216889508&cot=14)
 
+- **Value propositions** help SROSS projects better identify the core values of the tool and who it serves. Doing many value propositions as a team helps to further narrow down the multiple purposes of an SROSS project from various user perspectives. This also uncovers the differing perspectives from team members, maintainers and community contributors on ‘who’ the SROSS serves and why and helps to communicate overall expectations and goals for the SROSS. It also helps uncover assumptions people working in the SROSS have about their users. We recommend doing this exercise whenever there is strategical shift in the project or user base.
+    - Time needed for exercise: 1-2 hours
+    - Recommended size of group: 1-8
+    - Template: [Value Proposition](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559216889508&cot=14)
 - **A stakeholder analysis or map** helps a team to understand their own biases towards certain users types that are present in the team or community already and those that are not. Stakeholder maps ask teams to consider questions like ‘Who is missing from this map?’ and ‘Who do we think is important and for what reasons are they important?’ This helps to identify users and stakeholders that offer different opportunities to the SROSS and can be aligned with their project and science/research goals. For example, a funder might be central as a stakeholder as they offer financial support but they may not actively contribute to improving the code or science/research discoveries in the SROSS and therefore they may move from a central role to a periphery role at different stages the project undertakes. The power of this exercise is in understanding that it is never ‘final’ –  different users become important at different times in an OSS tool’s lifecycle. The ‘map’ is editable and is contributed to and viewed by as many contributors to the SROSS tool as possible. We recommend revisiting this map twice a year.
     - Time needed for exercise: 2-4 hours
     - Recommended size of group: 2-10
@@ -33,30 +32,23 @@ What gets built with whom is important. Sure, one can develop a "computation for
 **Critically analysing design, UI, Usability and UX**
 
 Understanding design better and respecting the processes without needing to be ‘experts’ in design came up as a critical part of SROSS’s journey to learn better user-centred processes and usability in their tools. The most difficult part however, is condensing many years of undergraduate and graduate study into a easily digestible format.
-    
+
 - **Primer on what types of design there are and what designers practice.** The best way to learn these terms is to seek out and speak to designers that identify as key job titles and terms as every designer will practice slightly differently. Most designers contributing to and involved in OSS in some way will be a generalist of sorts and practice many parts of the design spectrum in tandem.
-        - Time needed for exercise: 1 month
-        - Recommended size of group: 1-3
-        - Template: [Primer on design](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559304638612&cot=14)
-    
-
+    - Time needed for exercise: 1 month
+    - Recommended size of group: 1-3
+    - Template: [Primer on design](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559304638612&cot=14)
 - **Understanding Usability heuristics (Rules of thumb that help to find problems with existing interfaces) and adding your own heuristics that are specific to scientific and research OSS** is a way that SROSS can better understand the practical applications of design by applying a series of rules and questions to aspects of a ‘designed’ tool or application. This works best with a tool that includes a GUI/UI or some way the user interfaces with a command line but can also be applied to concepts, ideas and aspects of future design in a tool. However, it is better to use a ‘design principle’ to apply to tools without a GUI. Creating and amending a projects own heuristics can empower the team to understand what unique aspects of science and research software are not represented in existing design guidance and help communicate the values the science and research has in it’s tooling.
-        - Time needed for exercise: 2-5 days
-        - Recommended size of group: 4-6
-        - Template: [Usability heuristics](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559305132753&cot=14)
-    
-
+    - Time needed for exercise: 2-5 days
+    - Recommended size of group: 4-6
+    - Template: [Usability heuristics](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559305132753&cot=14)
 - **Interface inventory and GUI/UI library build.** Useful for projects that have a ‘GUI/UI’ and also useful for projects that are a series of documentations and commands in terminals/other softwares. A guide of how the interface should be constructed is useful documentation for teams and projects and often unearth where there are gaps, inconsistencies and miscommunications are in a GUI or content pattern. We recommend using Brad Frost’s template to categorise GUI/UI before analysis and library component creation.
-        - Time needed for exercise: Interface inventory 1-3 days, GUI/UI library build: 5 days +
-        - Recommended size of group: 3+
-        - Template: [Interface inventory and GUI/UI library](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559312695913&cot=14)
-    
-
+    - Time needed for exercise: Interface inventory 1-3 days, GUI/UI library build: 5 days +
+    - Recommended size of group: 3+
+    - Template: [Interface inventory and GUI/UI library](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559312695913&cot=14)
 - **WCAG and A11y web accessibility analysis** using the official guidelines for accessibility is the best way to ensure you’re meeting minimum standards for accessibility for impaired and disabled users. We recommend pairing accessibility guidelines with heuristic evaluation and other methods of assessing how well a design, UI or content is suited to users.
-        - Time needed for exercise: 5 days +
-        - Recommended size of group: 3-8
-        - Template: [WCAG and A11y web accessibility](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559312979961&cot=14)
-    
+    - Time needed for exercise: 5 days +
+    - Recommended size of group: 3-8
+    - Template: [WCAG and A11y web accessibility](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559312979961&cot=14)
 
 **Involving users in research gathering and research synthesis**
 
@@ -68,21 +60,15 @@ Understanding design better and respecting the processes without needing to be �
     - Time needed for exercise: 3 weeks average
     - Recommended size of group: 3-6
     - Template: [Write and send user feedback surveys](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559313400343&cot=14)
-
 - **Planning and Designing an open roadmap (with the community)** is a great way of making sure the feature requests start and remain user led. However, without clear criteria and guidance this can get speculative and have a sense of ‘fictional magic technology’ quickly. Ensure that as the team responsible for implementation you are keeping the features, improvements and fixes within the realms of possibility or communicating clearly why they would be difficult to build while still honouring the validity of the user need and exploring as many implementation options as possible. We created a feasibility worksheet to facilitate the complexity of features and work on OSS tools to help with this.
     - Time needed for exercise: 5 days to 3 months
     - Recommended size of group: 3-8
     - Template: [Planning and Designing an open roadmap](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559313472268&cot=14)
-
-
 - **Bringing in design and usability into every feature issues and acceptance criteria.** This can be done by making design a part of the pipeline process where tasks/issues move from labelled stage to stage with a built-in design review or design QA phase. Design review can be done at the estimation phase and design QA is done at the pre-release phase. This is difficult to implement if you do not already have phases of work and are not yet open about how work gets decided on. This is also feasible when you have some reliable design resource or are able to run through design review and QA without identifying as a designer.
-
   - Time needed for exercise: 3 days per round of design reviews
   - Recommended size of group: 2-4
   - Template: [Design and usability into every feature](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559313472664&cot=14)
-
-- **Building an OSS design team** is arguably one of the most complex and labour intensive exercises on the journey to great design and usability in OSS. It requires reaching out to designers in OSS communities such as [Open Source Design.net](https://opensourcedesign.net/) and ensuring you are asking for support in design and usability that will be implemented in the tool. Designer OSS volunteer turnover can be high due to many complex factors. Onboarding and ensuring that the designers are valued is critical to their success. 
-
+- **Building an OSS design team** is arguably one of the most complex and labour intensive exercises on the journey to great design and usability in OSS. It requires reaching out to designers in OSS communities such as [Open Source Design.net](https://opensourcedesign.net/) and ensuring you are asking for support in design and usability that will be implemented in the tool. Designer OSS volunteer turnover can be high due to many complex factors. Onboarding and ensuring that the designers are valued is critical to their success.
   - Time needed for exercise: Minimum of 3 months of onboarding and continued communication.
   - Recommended size of group: 1-3
   - Template: [Building an OSS design team](https://miro.com/app/board/uXjVM2k3my8=/?moveToWidget=3458764559313472784&cot=14)

--- a/content/part-1-the-state-of-SROSS/a-look-at-the-ecosystem.md
+++ b/content/part-1-the-state-of-SROSS/a-look-at-the-ecosystem.md
@@ -6,9 +6,9 @@ weight: 1
 ---
 ## What are these projects? Who maintains them? How do they start?
 
-The researchers and technologists we spoke with found their way to SROSS projects in diverse, but ultimately familiar ways. Many started out as PhD students, introduced to a software project through their research or by working in a lab. Others did the important work of convincing other academics who were developing tools to make them open. Participants mentioned having a deep desire to work on OSS in particular and seeing a serious need that their project could fill.  
+The researchers and technologists we spoke with found their way to SROSS projects in diverse, but ultimately familiar ways. Many started out as PhD students, introduced to a software project through their research or by working in a lab. Others did the important work of convincing other academics who were developing tools to make them open. Participants mentioned having a deep desire to work on OSS in particular and seeing a serious need that their project could fill.
 
-There was broad acknowledgment from participants that a large part of the appeal, interest, and passion that comes with working on OSS comes from the community of maintainers and users. One Drupal enthusiast from Brazil shared that in the Drupal community:  “the people are all using the technology and the software as an excuse to meet and share, but of course we are passionate about the technology, which all brought us together.” Along with shared interest and passion, the OSS community “usually takes \[a project] on and we get feedback or it takes a life of its own and people develop it and make it a lot better than it was at the beginning.”  Impact, scientific progress, and commitment to OSS are all values we saw in the participants’ responses, and are explored in the following chapter. 
+There was broad acknowledgment from participants that a large part of the appeal, interest, and passion that comes with working on OSS comes from the community of maintainers and users. One Drupal enthusiast from Brazil shared that in the Drupal community:  “the people are all using the technology and the software as an excuse to meet and share, but of course we are passionate about the technology, which all brought us together.” Along with shared interest and passion, the OSS community “usually takes \[a project] on and we get feedback or it takes a life of its own and people develop it and make it a lot better than it was at the beginning.”  Impact, scientific progress, and commitment to OSS are all values we saw in the participants’ responses, and are explored in the following chapter.
 
 To see the true range of projects we spoke with, in discipline, size, and scope, take a look at our [**ecosystem map**](/about/ecosystem-map/). If your project team would like to be added, please [**submit an issue here.**](https://github.com/simplysecure/USER_project/issues/new)
 
@@ -18,60 +18,34 @@ To see the true range of projects we spoke with, in discipline, size, and scope,
 
 **Disciplines represented:**
 * Vocal behavior
-* Geophysics 
-
+* Geophysics
 * Oceanography
-
-* Data science 
-
+* Data science
 * Biology
-
 * Genetics
-
 * Citizen science
-
 * Ethnography
-
-* Library science 
-
+* Library science
 * Astronomy
-
 * Meteorology
-
-* Earth systems 
-
+* Earth systems
 * Climate science
-
 * Engineering
-
 * Chemistry
-
 * Metagenomics
-
 * Geography
 
 **Types of software represented:**
 
 * Python data tools
-
-* Jupyter Notebooks 
-
-* Visualization 
-
+* Jupyter Notebooks
+* Visualization
 * Python libraries
-
-* Data analysis 
-
+* Data analysis
 * Data cleaning
-
 * Data collection for citizen science
-
-* Digital platforms 
-
+* Digital platforms
 * Data archive
-
 * PHP
-
 * Digital imaging
-
 * Creating access to HPC resources

--- a/content/part-1-the-state-of-SROSS/contributors-and-contribution.md
+++ b/content/part-1-the-state-of-SROSS/contributors-and-contribution.md
@@ -10,7 +10,7 @@ Contributors are commonly understood as people who work towards the mission of a
 
 ## The nature of contributions is evolving; design has yet to find a way to be recognized at large
 
-“Contribution means people working with me on the code.” The quote brings to light the kind of output a contributor adds to a project. While historically contributions were made with code or feature development, the notion of what “counts” as a contribution is evolving to include mentoring, event organization, conducting workshops, moderating forums, looking for funding, documentation, package management, supporting software distribution, design and a lot more. 
+“Contribution means people working with me on the code.” The quote brings to light the kind of output a contributor adds to a project. While historically contributions were made with code or feature development, the notion of what “counts” as a contribution is evolving to include mentoring, event organization, conducting workshops, moderating forums, looking for funding, documentation, package management, supporting software distribution, design and a lot more.
 
 People rarely brought up design as a part of contributions; in fact, only the designers we interviewed ever mentioned design as a contribution. One participant who identified as a designer said that it was their goal to work on open source but had to figure out ways without having to write HTML and CSS. Another participant who identifies themselves as an R&D engineer mentioned in the context of design that “I don’t think we have the opportunity to have them contribute a whole lot.”
 
@@ -18,7 +18,7 @@ People rarely brought up design as a part of contributions; in fact, only the de
 
 ## Who are the different contributors?
 
-Students, researchers, developers and designers are the most easily identifiable community members who contribute. “I was a student in science and software and I got to contribute to open source” recounts one developer participant. Another participant shared their story of getting students involved with usability studies. 
+Students, researchers, developers and designers are the most easily identifiable community members who contribute. “I was a student in science and software and I got to contribute to open source” recounts one developer participant. Another participant shared their story of getting students involved with usability studies.
 
 New developers from computer science backgrounds get attracted to contributing to open source as well. Most of the contributors fall in technical, conceptual and research areas. There was an evident dichotomy whether ‘users’ of the software are contributors. For projects where users can and do contribute, they contribute in different ways such as helping improve the terminology, helping choose the right language, providing feedback, or helping with software distribution by sharing it with colleagues. In other cases though, users were not considered contributors when they “just used the software or resources”. This dichotomy is further highlighted as one participant claimed that “many of the current contributors have been users, at some point” while another participant said that they “have a really hard time converting users to contributors”.
 
@@ -27,9 +27,7 @@ New developers from computer science backgrounds get attracted to contributing t
 This has been conveyed by most of the participants in one way or the other. One participant’s wholesome summary is worth mentioning, in which they indicated that they contribute:
 
 * to impact people’s lives with the software
-  
 * for the opportunity to challenge their skills, their knowledge
-
 * make technology accessible to people who may not have the means to pay for a license or have the freedom to change and enhance when it's necessary
 
 There have been other individual reasons that drive people to contribute such as their emotional connection with the project; in the case of students, to build on their academic study, improve grades, and/or fulfill work study, to be associated with a widely used software, job opportunities and career advancement, overall generosity, etc.
@@ -40,7 +38,7 @@ What makes contributors stick around in the long run however, is to be a part of
 
 The questions projects try to answer when setting up structures are - how to design the governance? Who gets to make decisions? Is there a decision making structure? Who all are involved? What contributions to keep or drop?
 
-Some projects have criteria and guidelines, code of conduct, dedicated channels as a part of their contributions governance. One participant who identified as the creator and main maintainer explained: 
+Some projects have criteria and guidelines, code of conduct, dedicated channels as a part of their contributions governance. One participant who identified as the creator and main maintainer explained:
 
 _“We have several criteria for integrating new features in terms of number of citations. When has it been released? Is it in the scope of the projects? Is it maintainable? … \[the process is that]every PR that is a technical contribution, gets reviewed, at least by two people so that we make sure that it's valuable in terms of experience, homogeneity, and document discoverability.”_
 

--- a/content/process/_index.md
+++ b/content/process/_index.md
@@ -14,19 +14,19 @@ Our research followed an iterative Human-Centered Design approach using multiple
 
 **1.** **Ecosystem analysis & Community Observation **
 
-We spent the first two months of this research project analyzing data and information about the open source research software ecosystem to better understand existing resources, programs, and efforts to support research software for science. In this period, we reviewed relevant literature on design and usability in OSS, and on scientific OSS in particular. 
+We spent the first two months of this research project analyzing data and information about the open source research software ecosystem to better understand existing resources, programs, and efforts to support research software for science. In this period, we reviewed relevant literature on design and usability in OSS, and on scientific OSS in particular.
 
 We also began compiling information about projects and players in the ecosystem and began building what became our [Ecosystem Map](/about/ecosystem-map/), which enabled us to understand the overlapping web of tools, projects, people, and funders that make up the SROSS space.
 
-While the USER research team delved into the papers, blogs, repos and written accounts of key terms and subjects, we also made social connections with key SROSS funders, projects, institutions and individuals across conferences and community events like CZI Open Science and OpenRIT. We’ve learned from past design research projects in OSS that important context and nuance is revealed through relationship building, so establishing these connections contributed to our exploratory research practice. Developing an understanding of and learning to participate in the culture and community of OSS, not unlike how OSS itself gets built and maintained, comes from connecting with other people who value the work. From these connections, we built relationships that fed the research activities and also allowed our design researchers and the scientists, researchers and designers we met to speak on equitable, social terms and gather initial human-centered insights. 
+While the USER research team delved into the papers, blogs, repos and written accounts of key terms and subjects, we also made social connections with key SROSS funders, projects, institutions and individuals across conferences and community events like CZI Open Science and OpenRIT. We’ve learned from past design research projects in OSS that important context and nuance is revealed through relationship building, so establishing these connections contributed to our exploratory research practice. Developing an understanding of and learning to participate in the culture and community of OSS, not unlike how OSS itself gets built and maintained, comes from connecting with other people who value the work. From these connections, we built relationships that fed the research activities and also allowed our design researchers and the scientists, researchers and designers we met to speak on equitable, social terms and gather initial human-centered insights.
 
-This process helped us describe and situate ourselves within this particular landscape: what projects currently exist, what types of funding are available to projects, what types of support and resources exist, what types of needs have been identified in the ecosystem, the language used by projects, the tools used in the ecosystem, and the metrics and measurements that may be in use by projects. 
+This process helped us describe and situate ourselves within this particular landscape: what projects currently exist, what types of funding are available to projects, what types of support and resources exist, what types of needs have been identified in the ecosystem, the language used by projects, the tools used in the ecosystem, and the metrics and measurements that may be in use by projects.
 
-From the scan we were able to understand what questions we needed to ask in our subsequent surveys and interviews. It also helped us to develop an outreach plan and partner with ecosystem stakeholder organizations to publicize our survey and gather enthusiasm for our research. 
+From the scan we were able to understand what questions we needed to ask in our subsequent surveys and interviews. It also helped us to develop an outreach plan and partner with ecosystem stakeholder organizations to publicize our survey and gather enthusiasm for our research.
 
 **2. Online Surveys (48 responses)**
 
-Our research and outreach at conferences helped to inform preliminary findings and hypotheses, creating the foundation for our published [survey](https://github.com/simplysecure/USER_project/blob/main/user-survey.md). We ran two versions of the survey (one longer version with both qualitative and quantitative questions, and one shorter version with only multiple-choice questions) to gather broad signals about how the community prioritizes, describes, and self-assesses on usability and design issues. We invited the project contributors we’d met in person and those we’d identified in our ecosystem research to participate, and shared in communication channels and email lists frequented by communities of interest. We received 48 total responses to our survey. 
+Our research and outreach at conferences helped to inform preliminary findings and hypotheses, creating the foundation for our published [survey](https://github.com/simplysecure/USER_project/blob/main/user-survey.md). We ran two versions of the survey (one longer version with both qualitative and quantitative questions, and one shorter version with only multiple-choice questions) to gather broad signals about how the community prioritizes, describes, and self-assesses on usability and design issues. We invited the project contributors we’d met in person and those we’d identified in our ecosystem research to participate, and shared in communication channels and email lists frequented by communities of interest. We received 48 total responses to our survey.
 
 **3.** **Interviews (27)**
 
@@ -36,19 +36,19 @@ We completed 27 hour-long interviews for this project from December 2022 through
 * How team dynamics and trust affects those choices.
 * What teams would need to be interested in or able to prioritize usability and design in their work.
 
-**4. Data compilation and synthesis **
+**4. Data compilation and synthesis**
 
-Our six-person research team then collaborated virtually and in-person to organize, synthesize, and analyze the qualitative and quantitative data we’d collected through the surveys and interviews. We used a combination of methods to analyze our recorded interview transcripts, interview notes, and survey results, including: 
+Our six-person research team then collaborated virtually and in-person to organize, synthesize, and analyze the qualitative and quantitative data we’d collected through the surveys and interviews. We used a combination of methods to analyze our recorded interview transcripts, interview notes, and survey results, including:
 
 * A collaborative Miro board where we practiced card sorting on a massive scale to organize key findings and quotes
-* A qualitative code book in Notion that helped us to sort quotations from interview participants 
+* A qualitative code book in Notion that helped us to sort quotations from interview participants
 * Qualitative and quantitative analysis of survey results in Google Sheets
 
 
 
 ## Limitations
 
-Our research tried to cover a wide range of projects and people working on them. To understand what our results apply to, we want to speak to the research’s limitations. 
+Our research tried to cover a wide range of projects and people working on them. To understand what our results apply to, we want to speak to the research’s limitations.
 
 Our research focused mainly on United States-based (or founded) projects with some European-based projects included. This has two reasons. Firstly, the organization that funded this research, the Sloan Foundation, focuses on research and academia in the US. Secondly, a lot of projects in open source research software are created at universities in the US or Europe, because these nations and states and their economies are typically able to fund such projects.
 

--- a/themes/cupper/static/css/custom.css
+++ b/themes/cupper/static/css/custom.css
@@ -225,13 +225,17 @@ figure {
   background-position: center center;
 }
 
+.wrapper-main > #main ul li {
+  margin: 1.25rem 0;
+  text-indent: -40px;
+}
+
 .wrapper-main>#main ul li:before {
   content: ">>";
   font-family: IBM Plex Mono, monospace;
   font-weight: bold;
   position: relative;
-  top: 36px;
-  left: -40px;
+  margin-right: 10px
 }
 
 .wrapper-main>#main ul {


### PR DESCRIPTION
This PR solves the misalignment design bug in the list styling that could be seen in some pages like https://user-project.superbloom.design/process/literature-review/

Some of the list items in the markdown had an extra newline, causing it to act like a paragraph. The design of the list items was done based on that. I have removed all the extra newlines from the markdowns which had that, and modified the design such that it works with just list item text without a paragraph inside.